### PR TITLE
fix: fix major version tagging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
 
     - name: Release
       uses: cycjimmy/semantic-release-action@v2
+      id: semantic-release
       with:
         extra_plugins: |
           @semantic-release/exec
@@ -71,3 +72,13 @@ jobs:
           ]
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Move major version tag
+      if: steps.semantic-release.outputs.new_release_published == 'true'
+      env:
+        VERION_TAG: v${{steps.semantic-release.outputs.new_release_major_version}}
+      run: |
+        git tag -d ${{ env.VERION_TAG }}
+        git push origin :${{ env.VERION_TAG }}
+        git tag ${{ env.VERION_TAG }}
+        git push origin ${{ env.VERION_TAG }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,17 +1,17 @@
 {
-    "plugins": [
-      "@semantic-release/github",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/commit-analyzer",
-      ["@semantic-release/changelog", {
-          "changelogFile": "CHANGELOG.md"
-      }],
-      ["@semantic-release/npm", {
-          "npmPublish": false
-      }],
-      ["@semantic-release/git", {
-          "assets": ["package.json", "CHANGELOG.md"],
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }]
-    ]
-  }
+  "plugins": [
+    "@semantic-release/github",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/commit-analyzer",
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    ["@semantic-release/git", {
+      "assets": ["package.json","package-lock.json", "CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
+  ]
+}


### PR DESCRIPTION
This PR sets up the functionality for major version tagging so that the latest version of @v1 can be referenced instead of individual commits or releases