### PR TITLE
Feat/hxnce 994 update aws sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "aws-sdk": "^2.1365.0",
+    "@aws-sdk/client-ecr": "^3.353.0",
+    "@aws-sdk/client-sts": "^3.353.0",
     "dockerode": "^3.3.5",
     "whatwg-url": "^12.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
-    "aws-sdk": "^2.1365.0",
     "@aws-sdk/client-ecr": "^3.353.0",
     "@aws-sdk/client-sts": "^3.353.0",
     "dockerode": "^3.3.5",

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -1,5 +1,5 @@
 import { ECR } from "@aws-sdk/client-ecr";
-import AWS_STS, { STS, GetCallerIdentityCommand, AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { STS, GetCallerIdentityCommand, AssumeRoleCommand } from "@aws-sdk/client-sts";
 import * as core from '@actions/core';
 import { Pull } from './pull';
 import { Push } from './push';

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -70,9 +70,9 @@ export class Copy {
       }
       const ecrPullClient = new ECR({
         credentials: {
-          accessKeyId: accessKeyId,
-          secretAccessKey: secretAccessKey,
-          sessionToken: sessionToken,
+          accessKeyId,
+          secretAccessKey,
+          sessionToken,
         },
       });
 

--- a/src/ecr.ts
+++ b/src/ecr.ts
@@ -1,4 +1,4 @@
-import AWS_ECR, { ECR } from "@aws-sdk/client-ecr";
+import { ECR, GetAuthorizationTokenCommandInput } from "@aws-sdk/client-ecr";
 import * as core from '@actions/core';
 import * as docker from './docker';
 
@@ -8,7 +8,7 @@ export async function login(
 ): Promise<string> {
   core.debug(`getting ECR auth token with account id ${accountId}`);
 
-  const authTokenRequest: AWS_ECR.GetAuthorizationTokenCommandInput = {};
+  const authTokenRequest: GetAuthorizationTokenCommandInput = {};
   if (accountId !== undefined) {
     authTokenRequest.registryIds = [accountId];
   }

--- a/src/ecr.ts
+++ b/src/ecr.ts
@@ -1,4 +1,4 @@
-import { ECR, GetAuthorizationTokenCommandInput } from "@aws-sdk/client-ecr";
+import { ECR } from "@aws-sdk/client-ecr";
 import * as core from '@actions/core';
 import * as docker from './docker';
 
@@ -7,13 +7,8 @@ export async function login(
   accountId?: string
 ): Promise<string> {
   core.debug(`getting ECR auth token with account id ${accountId}`);
-
-  const authTokenRequest: GetAuthorizationTokenCommandInput = {};
-  if (accountId !== undefined) {
-    authTokenRequest.registryIds = [accountId];
-  }
   const authTokenResponse = await ecrClient
-    .getAuthorizationToken(authTokenRequest);
+    .getAuthorizationToken({});
 
   if (
     authTokenResponse.authorizationData === undefined ||

--- a/src/ecr.ts
+++ b/src/ecr.ts
@@ -1,20 +1,19 @@
-import * as aws from 'aws-sdk';
+import AWS_ECR, { ECR } from "@aws-sdk/client-ecr";
 import * as core from '@actions/core';
 import * as docker from './docker';
 
 export async function login(
-  ecrClient: aws.ECR,
+  ecrClient: ECR,
   accountId?: string
 ): Promise<string> {
   core.debug(`getting ECR auth token with account id ${accountId}`);
 
-  const authTokenRequest: aws.ECR.GetAuthorizationTokenRequest = {};
+  const authTokenRequest: AWS_ECR.GetAuthorizationTokenCommandInput = {};
   if (accountId !== undefined) {
     authTokenRequest.registryIds = [accountId];
   }
   const authTokenResponse = await ecrClient
-    .getAuthorizationToken(authTokenRequest)
-    .promise();
+    .getAuthorizationToken(authTokenRequest);
 
   if (
     authTokenResponse.authorizationData === undefined ||

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import * as aws from 'aws-sdk';
+import { ECR } from "@aws-sdk/client-ecr";
 import * as core from '@actions/core';
 import { Copy } from './copy';
 import { Push } from './push';
@@ -16,7 +16,7 @@ async function run(): Promise<void> {
     const sourceRoleArn = core.getInput('source-role-arn');
     const immutable: boolean =
       (core.getInput('immutable', { required: false }) || 'false') === 'true';
-    const ecrClient = new aws.ECR();
+    const ecrClient = new ECR();
 
     if (repository === undefined || repository.length === 0) {
       core.setFailed('Repository parameter is missing');

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ async function run(): Promise<void> {
     const sourceRoleArn = core.getInput('source-role-arn');
     const immutable: boolean =
       (core.getInput('immutable', { required: false }) || 'false') === 'true';
-    const ecrClient = new ECR();
+    const ecrClient = new ECR({});
 
     if (repository === undefined || repository.length === 0) {
       core.setFailed('Repository parameter is missing');

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -1,11 +1,11 @@
-import * as aws from 'aws-sdk';
+import { ECR } from "@aws-sdk/client-ecr";
 import * as core from '@actions/core';
 import * as docker from './docker';
 import * as ecrHelper from './ecr';
 
 export class Pull {
   constructor(
-    readonly ecrClient: aws.ECR,
+    readonly ecrClient: ECR,
     readonly repository: string,
     readonly tag: string,
     readonly accountId?: string,

--- a/src/push.ts
+++ b/src/push.ts
@@ -1,5 +1,8 @@
-import * as aws from 'aws-sdk';
-import { ECR } from "@aws-sdk/client-ecr";
+import { 
+  ECR, 
+  DescribeRepositoriesCommand,
+  CreateRepositoryCommand,
+  RepositoryNotFoundException } from "@aws-sdk/client-ecr";
 import * as core from '@actions/core';
 import * as docker from './docker';
 import * as ecrHelper from './ecr';
@@ -27,36 +30,30 @@ export class Push {
     repository: string,
     immutable: boolean
   ): Promise<void> {
+    const command = new DescribeRepositoriesCommand({
+      repositoryNames: [repository]
+    });
+
     try {
       core.debug('Checking repository exists.');
       await this.ecrClient
-        .describeRepositories({
-          repositoryNames: [repository],
-        })
-        .promise();
+        .send(command);
     } catch (err) {
-      const e = err as aws.AWSError;
-      if (e) {
-        if (e.code === 'RepositoryNotFoundException') {
-          const createRepoOptions: aws.ECR.Types.CreateRepositoryRequest = {
-            repositoryName: repository,
-            imageTagMutability: immutable ? 'IMMUTABLE' : 'MUTABLE',
-          };
-          core.debug(
-            `Repository doesn't exist, creating with ${JSON.stringify(
-              createRepoOptions
-            )}`
-          );
-          await this.ecrClient.createRepository(createRepoOptions).promise();
-        } else {
-          core.setFailed(
-            `Error testing for repository existence: ${e.message}`
-          );
-        }
+      if (err instanceof RepositoryNotFoundException) {
+        const command = new CreateRepositoryCommand({
+          repositoryName: repository,
+          imageTagMutability: immutable ? 'IMMUTABLE' : 'MUTABLE',
+        });
+        core.debug(
+          `Repository doesn't exist, creating with ${JSON.stringify(
+            command
+          )}`
+        );
+        await this.ecrClient.send(command);
       } else if (err instanceof Error) {
-        core.setFailed(`Error with create repository: ${err.message}`);
+      core.setFailed(`Error with create repository: ${err.message}`);
       } else {
-        core.setFailed(`Unknown error with create repository: ${err}`);
+      core.setFailed(`Unknown error with create repository: ${err}`);
       }
     }
   }

--- a/src/push.ts
+++ b/src/push.ts
@@ -1,10 +1,11 @@
 import * as aws from 'aws-sdk';
+import { ECR } from "@aws-sdk/client-ecr";
 import * as core from '@actions/core';
 import * as docker from './docker';
 import * as ecrHelper from './ecr';
 export class Push {
   constructor(
-    readonly ecrClient: aws.ECR,
+    readonly ecrClient: ECR,
     readonly repository: string,
     readonly tag: string,
     readonly immutable: boolean

--- a/src/push.ts
+++ b/src/push.ts
@@ -30,26 +30,26 @@ export class Push {
     repository: string,
     immutable: boolean
   ): Promise<void> {
-    const command = new DescribeRepositoriesCommand({
+    const describeRepositories = new DescribeRepositoriesCommand({
       repositoryNames: [repository]
     });
 
     try {
       core.debug('Checking repository exists.');
       await this.ecrClient
-        .send(command);
+        .send(describeRepositories);
     } catch (err) {
       if (err instanceof RepositoryNotFoundException) {
-        const command = new CreateRepositoryCommand({
+        const createRepository = new CreateRepositoryCommand({
           repositoryName: repository,
           imageTagMutability: immutable ? 'IMMUTABLE' : 'MUTABLE',
         });
         core.debug(
           `Repository doesn't exist, creating with ${JSON.stringify(
-            command
+            createRepository
           )}`
         );
-        await this.ecrClient.send(command);
+        await this.ecrClient.send(createRepository);
       } else if (err instanceof Error) {
       core.setFailed(`Error with create repository: ${err.message}`);
       } else {


### PR DESCRIPTION
v2 of the AWS SDK for JS is deprecated, so this moves to v3. 
I started by running this tool: https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html
I tried to mimic the calls of the original repo as best I could, but there are a few changes:
- Error handling using `instanceof`: https://aws.amazon.com/blogs/developer/service-error-handling-modular-aws-sdk-js/
- package/command modularity and different command API https://aws.amazon.com/blogs/developer/modular-packages-in-aws-sdk-for-javascript/

This hasn't been tested but I plan on porting the new release version to a workflow shortly to see whether it continues to work.